### PR TITLE
Replace vercel branding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,17 @@
-# Generate a random secret: https://generate-secret.vercel.app/32 or `openssl rand -base64 32`
+# Generate a random secret with `openssl rand -base64 32`
 AUTH_SECRET=****
 
-# The following keys below are automatically created and
-# added to your environment when you deploy on vercel
+# Set the following keys in your environment
 
 # Get your xAI API Key here for chat and image models: https://console.x.ai/
 XAI_API_KEY=****
 
-# Instructions to create a Vercel Blob Store here: https://vercel.com/docs/storage/vercel-blob
+# Instructions to create a blob store
 BLOB_READ_WRITE_TOKEN=****
 
-# Instructions to create a PostgreSQL database here: https://vercel.com/docs/storage/vercel-postgres/quickstart
+# Instructions to create a PostgreSQL database
 POSTGRES_URL=****
 
 
-# Instructions to create a Redis store here:
-# https://vercel.com/docs/redis
+# Instructions to create a Redis store
 REDIS_URL=****

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-<a href="https://chat.vercel.ai/">
-  <img alt="Next.js 14 and App Router-ready AI chatbot." src="app/(chat)/opengraph-image.png">
-  <h1 align="center">Chat SDK</h1>
-</a>
+<img alt="Next.js 14 and App Router-ready AI chatbot." src="app/(chat)/opengraph-image.png">
+<h1 align="center">Chat SDK</h1>
 
 <p align="center">
     Chat SDK is a free, open-source template built with Next.js and the AI SDK that helps you quickly build powerful chatbot applications.
@@ -29,8 +27,8 @@
   - Styling with [Tailwind CSS](https://tailwindcss.com)
   - Component primitives from [Radix UI](https://radix-ui.com) for accessibility and flexibility
 - Data Persistence
-  - [Neon Serverless Postgres](https://vercel.com/marketplace/neon) for saving chat history and user data
-  - [Vercel Blob](https://vercel.com/storage/blob) for efficient file storage
+  - Neon Serverless Postgres for saving chat history and user data
+  - Blob storage for efficient file storage
 - [Auth.js](https://authjs.dev)
   - Simple and secure authentication
 
@@ -38,21 +36,15 @@
 
 This template ships with [xAI](https://x.ai) `grok-2-1212` as the default chat model. However, with the [AI SDK](https://sdk.vercel.ai/docs), you can switch LLM providers to [OpenAI](https://openai.com), [Anthropic](https://anthropic.com), [Cohere](https://cohere.com/), and [many more](https://sdk.vercel.ai/providers/ai-sdk-providers) with just a few lines of code.
 
-## Deploy Your Own
-
-You can deploy your own version of the Next.js AI Chatbot to Vercel with one click:
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai-chatbot&env=AUTH_SECRET&envDescription=Learn+more+about+how+to+get+the+API+Keys+for+the+application&envLink=https%3A%2F%2Fgithub.com%2Fvercel%2Fai-chatbot%2Fblob%2Fmain%2F.env.example&demo-title=AI+Chatbot&demo-description=An+Open-Source+AI+Chatbot+Template+Built+With+Next.js+and+the+AI+SDK+by+Vercel.&demo-url=https%3A%2F%2Fchat.vercel.ai&products=%5B%7B%22type%22%3A%22integration%22%2C%22protocol%22%3A%22ai%22%2C%22productSlug%22%3A%22grok%22%2C%22integrationSlug%22%3A%22xai%22%7D%2C%7B%22type%22%3A%22integration%22%2C%22protocol%22%3A%22storage%22%2C%22productSlug%22%3A%22neon%22%2C%22integrationSlug%22%3A%22neon%22%7D%2C%7B%22type%22%3A%22integration%22%2C%22protocol%22%3A%22storage%22%2C%22productSlug%22%3A%22upstash-kv%22%2C%22integrationSlug%22%3A%22upstash%22%7D%2C%7B%22type%22%3A%22blob%22%7D%5D)
 
 ## Running locally
 
-You will need to use the environment variables [defined in `.env.example`](.env.example) to run Next.js AI Chatbot. It's recommended you use [Vercel Environment Variables](https://vercel.com/docs/projects/environment-variables) for this, but a `.env` file is all that is necessary.
+You will need to use the environment variables [defined in `.env.example`](.env.example) to run Next.js AI Chatbot. A `.env` file is all that is necessary.
 
 > Note: You should not commit your `.env` file or it will expose secrets that will allow others to control access to your various AI and authentication provider accounts.
 
-1. Install Vercel CLI: `npm i -g vercel`
-2. Link local instance with Vercel and GitHub accounts (creates `.vercel` directory): `vercel link`
-3. Download your environment variables: `vercel env pull`
+1. Install dependencies
+2. Start the development server
 
 ```bash
 pnpm install

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List
+from openai import AsyncOpenAI
+import os
+
+app = FastAPI()
+client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+class ChatRequest(BaseModel):
+    messages: List[Message]
+
+@app.post("/api/chat")
+async def chat(req: ChatRequest):
+    response = await client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": m.role, "content": m.content} for m in req.messages],
+    )
+    return {"message": response.choices[0].message.content}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+openai

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -7,7 +7,7 @@ import { useWindowSize } from 'usehooks-ts';
 import { ModelSelector } from '@/components/model-selector';
 import { SidebarToggle } from '@/components/sidebar-toggle';
 import { Button } from '@/components/ui/button';
-import { PlusIcon, VercelIcon } from './icons';
+import { PlusIcon } from './icons';
 import { useSidebar } from './ui/sidebar';
 import { memo } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
@@ -71,18 +71,6 @@ function PureChatHeader({
         />
       )}
 
-      <Button
-        className="bg-zinc-900 dark:bg-zinc-100 hover:bg-zinc-800 dark:hover:bg-zinc-200 text-zinc-50 dark:text-zinc-900 hidden md:flex py-1.5 px-2 h-fit md:h-[34px] order-4 md:ml-auto"
-        asChild
-      >
-        <Link
-          href={`https://vercel.com/new/clone?repository-url=https://github.com/vercel/ai-chatbot&env=AUTH_SECRET&envDescription=Learn more about how to get the API Keys for the application&envLink=https://github.com/vercel/ai-chatbot/blob/main/.env.example&demo-title=AI Chatbot&demo-description=An Open-Source AI Chatbot Template Built With Next.js and the AI SDK by Vercel.&demo-url=https://chat.vercel.ai&products=[{"type":"integration","protocol":"ai","productSlug":"grok","integrationSlug":"xai"},{"type":"integration","protocol":"storage","productSlug":"neon","integrationSlug":"neon"},{"type":"integration","protocol":"storage","productSlug":"upstash-kv","integrationSlug":"upstash"},{"type":"blob"}]`}
-          target="_noblank"
-        >
-          <VercelIcon size={16} />
-          Deploy with Vercel
-        </Link>
-      </Button>
     </header>
   );
 }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -58,6 +58,7 @@ export function Chat({
     experimental_resume,
     data,
   } = useChat({
+    api: 'http://localhost:8000/api/chat',
     id,
     initialMessages,
     experimental_throttle: 100,

--- a/components/data-stream-handler.tsx
+++ b/components/data-stream-handler.tsx
@@ -22,7 +22,7 @@ export type DataStreamDelta = {
 };
 
 export function DataStreamHandler({ id }: { id: string }) {
-  const { data: dataStream } = useChat({ id });
+  const { data: dataStream } = useChat({ id, api: 'http://localhost:8000/api/chat' });
   const { artifact, setArtifact, setMetadata } = useArtifact();
   const lastProcessedIndex = useRef(-1);
 

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -56,24 +56,6 @@ export const AttachmentIcon = () => {
   );
 };
 
-export const VercelIcon = ({ size = 17 }) => {
-  return (
-    <svg
-      height={size}
-      strokeLinejoin="round"
-      viewBox="0 0 16 16"
-      width={size}
-      style={{ color: 'currentcolor' }}
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M8 1L16 15H0L8 1Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-};
 
 export const GitIcon = () => {
   return (

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,11 +5,7 @@ const nextConfig: NextConfig = {
     ppr: true,
   },
   images: {
-    remotePatterns: [
-      {
-        hostname: 'avatar.vercel.sh',
-      },
-    ],
+    remotePatterns: [],
   },
 };
 


### PR DESCRIPTION
## Summary
- strip vercel references from documentation and code
- set up a simple FastAPI backend using `gpt-4o-mini`
- point chat components to the new backend

## Testing
- `pnpm lint` *(fails: Connect Timeout Error)*